### PR TITLE
fix example app lint errors

### DIFF
--- a/examples/src/App.js
+++ b/examples/src/App.js
@@ -1,6 +1,7 @@
+/*eslint new-cap: [2, {"capIsNewExceptions": ["Map"]}]*/
 import React, { Component } from 'react';
 import JSONTree from 'react-json-tree';
-import { Map } from 'immutable'
+import { Map } from 'immutable';
 
 export default class App extends Component {
   render() {


### PR DESCRIPTION
This is causing `prepublish` to error out.