### PR TITLE
Add babel-runtime for `Symbol`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "clean": "rimraf lib",
-    "build": "babel src --out-dir lib",
+    "build": "babel src --optional runtime --out-dir lib",
     "lint": "eslint src test examples",
     "test": "NODE_ENV=test mocha --compilers js:babel/register --recursive",
     "test:watch": "NODE_ENV=test mocha --compilers js:babel/register --recursive --watch",
@@ -47,6 +47,7 @@
     "react": ">=0.13.3 || ^0.14.0-beta3"
   },
   "dependencies": {
+    "babel-runtime": "^5.8.20",
     "react-mixin": "^1.7.0"
   }
 }


### PR DESCRIPTION
Presently, the [usage of `Symbol.iterator`](https://github.com/chibicode/react-json-tree/blob/c435e5221784aaa59355b31bfdc45d5efed43fa3/src/obj-type.js#L3) throws in engines that don't natively support `Symbol`. For example, Safari 8.

I've added `babel-runtime` to polyfill that out.