### PR TITLE
customize styling

### DIFF
--- a/src/JSONArrayNode.js
+++ b/src/JSONArrayNode.js
@@ -61,7 +61,7 @@ export default class JSONArrayNode extends React.Component {
         if (typeof this.props.previousData !== 'undefined' && this.props.previousData !== null) {
           prevData = this.props.previousData[idx];
         }
-        const node = grabNode(idx, element, prevData, this.props.theme);
+        const node = grabNode(idx, element, prevData, this.props.theme, this.props.styles, this.props.getItemString);
         if (node !== false) {
           childNodes.push(node);
         }
@@ -74,11 +74,11 @@ export default class JSONArrayNode extends React.Component {
 
   // Returns the "n Items" string for this node, generating and
   // caching it if it hasn't been created yet.
-  getItemString() {
+  getItemString(itemType) {
     if (!this.itemString) {
       this.itemString = this.props.data.length + ' item' + (this.props.data.length !== 1 ? 's' : '');
     }
-    return this.itemString;
+    return this.props.getItemString('Array', this.props.data, this.itemString, itemType);
   }
 
   render() {
@@ -105,18 +105,24 @@ export default class JSONArrayNode extends React.Component {
     }
     return (
       <li style={containerStyle}>
-        <JSONArrow theme={this.props.theme} open={this.state.expanded} onClick={::this.handleClick}/>
+        <JSONArrow theme={this.props.theme} open={this.state.expanded} onClick={::this.handleClick} style={this.props.styles.getArrowStyle(this.state.expanded)}/>
         <label style={{
           ...styles.label,
-          color: this.props.theme.base0D
+          color: this.props.theme.base0D,
+          ...this.props.styles.getLabelStyle('Array', this.state.expanded)
         }} onClick={::this.handleClick}>
           {this.props.keyName}:
         </label>
-        <span style={spanStyle} onClick={::this.handleClick}>
-          <span style={styles.spanType}>[]</span>
-          {this.getItemString()}
+        <span style={{
+          ...spanStyle,
+          ...this.props.styles.getPreviewStyle('Array', this.state.expanded)
+        }} onClick={::this.handleClick}>
+          {this.getItemString(<span style={styles.spanType}>[]</span>)}
         </span>
-        <ol style={childListStyle}>
+        <ol style={{
+          ...childListStyle,
+          ...this.props.styles.getListStyle('Array', this.state.expanded)
+        }}>
           {childNodes}
         </ol>
       </li>

--- a/src/JSONArrayNode.js
+++ b/src/JSONArrayNode.js
@@ -115,7 +115,7 @@ export default class JSONArrayNode extends React.Component {
         </label>
         <span style={{
           ...spanStyle,
-          ...this.props.styles.getPreviewStyle('Array', this.state.expanded)
+          ...this.props.styles.getItemStringStyle('Array', this.state.expanded)
         }} onClick={::this.handleClick}>
           {this.getItemString(<span style={styles.spanType}>[]</span>)}
         </span>

--- a/src/JSONArrayNode.js
+++ b/src/JSONArrayNode.js
@@ -78,7 +78,7 @@ export default class JSONArrayNode extends React.Component {
     if (!this.itemString) {
       this.itemString = this.props.data.length + ' item' + (this.props.data.length !== 1 ? 's' : '');
     }
-    return this.props.getItemString('Array', this.props.data, this.itemString, itemType);
+    return this.props.getItemString('Array', this.props.data, itemType, this.itemString);
   }
 
   render() {

--- a/src/JSONArrow.js
+++ b/src/JSONArrow.js
@@ -37,6 +37,10 @@ export default class JSONArrow extends React.Component {
         ...styles.open
       };
     }
+    style = {
+      ...style,
+      ...this.props.style
+    };
     return <div style={style} onClick={this.props.onClick}/>;
   }
 }

--- a/src/JSONBooleanNode.js
+++ b/src/JSONBooleanNode.js
@@ -29,11 +29,15 @@ export default class JSONBooleanNode extends React.Component {
       <li style={{ ...styles.base, backgroundColor }} onClick={::this.handleClick}>
         <label style={{
           ...styles.label,
-          color: this.props.theme.base0D
+          color: this.props.theme.base0D,
+          ...this.props.styles.getLabelStyle('Boolean', true)
         }}>
           {this.props.keyName}:
         </label>
-        <span style={{ color: this.props.theme.base09 }}>{truthString}</span>
+        <span style={{
+          color: this.props.theme.base09,
+          ...this.props.styles.getValueStyle('Boolean', true)
+        }}>{truthString}</span>
       </li>
     );
   }

--- a/src/JSONDateNode.js
+++ b/src/JSONDateNode.js
@@ -28,11 +28,15 @@ export default class JSONDateNode extends React.Component {
       <li style={{ ...styles.base, backgroundColor }} onClick={::this.handleClick}>
         <label style={{
           ...styles.label,
-          color: this.props.theme.base0D
+          color: this.props.theme.base0D,
+          ...this.props.styles.getLabelStyle('Date', true)
         }}>
           {this.props.keyName}:
         </label>
-        <span style={{ color: this.props.theme.base0B }}>{this.props.value.toISOString()}</span>
+        <span style={{
+          color: this.props.theme.base0B,
+          ...this.props.styles.getValueStyle('Date', true)
+        }}>{this.props.value.toISOString()}</span>
       </li>
     );
   }

--- a/src/JSONIterableNode.js
+++ b/src/JSONIterableNode.js
@@ -96,7 +96,7 @@ export default class JSONIterableNode extends React.Component {
       }
       this.itemString = count + ' entr' + (count !== 1 ? 'ies' : 'y');
     }
-    return this.props.getItemString('Iterable', this.props.data, this.itemString, itemType);
+    return this.props.getItemString('Iterable', this.props.data, itemType, this.itemString);
   }
 
   render() {

--- a/src/JSONIterableNode.js
+++ b/src/JSONIterableNode.js
@@ -133,7 +133,7 @@ export default class JSONIterableNode extends React.Component {
         </label>
         <span style={{
           ...spanStyle,
-          ...this.props.styles.getPreviewStyle('Iterable', this.state.expanded)
+          ...this.props.styles.getItemStringStyle('Iterable', this.state.expanded)
         }} onClick={::this.handleClick}>
           {this.getItemString(<span style={styles.spanType}>()</span>)}
         </span>

--- a/src/JSONIterableNode.js
+++ b/src/JSONIterableNode.js
@@ -70,7 +70,7 @@ export default class JSONIterableNode extends React.Component {
         if (typeof this.props.previousData !== 'undefined' && this.props.previousData !== null) {
           prevData = this.props.previousData[key];
         }
-        const node = grabNode(key, value, prevData, this.props.theme);
+        const node = grabNode(key, value, prevData, this.props.theme, this.props.styles, this.props.getItemString);
         if (node !== false) {
           childNodes.push(node);
         }
@@ -83,7 +83,7 @@ export default class JSONIterableNode extends React.Component {
 
   // Returns the "n entries" string for this node, generating and
   // caching it if it hasn't been created yet.
-  getItemString() {
+  getItemString(itemType) {
     if (!this.itemString) {
       const { data } = this.props;
       let count = 0;
@@ -96,7 +96,7 @@ export default class JSONIterableNode extends React.Component {
       }
       this.itemString = count + ' entr' + (count !== 1 ? 'ies' : 'y');
     }
-    return this.itemString;
+    return this.props.getItemString('Iterable', this.props.data, this.itemString, itemType);
   }
 
   render() {
@@ -123,18 +123,24 @@ export default class JSONIterableNode extends React.Component {
     }
     return (
       <li style={containerStyle}>
-        <JSONArrow theme={this.props.theme} open={this.state.expanded} onClick={::this.handleClick}/>
+        <JSONArrow theme={this.props.theme} open={this.state.expanded} onClick={::this.handleClick} style={this.props.styles.getArrowStyle(this.state.expanded)} />
         <label style={{
           ...styles.label,
-          color: this.props.theme.base0D
+          color: this.props.theme.base0D,
+          ...this.props.styles.getLabelStyle('Iterable', this.state.expanded)
         }} onClick={::this.handleClick}>
           {this.props.keyName}:
         </label>
-        <span style={spanStyle} onClick={::this.handleClick}>
-          <span style={styles.spanType}>()</span>
-          {this.getItemString()}
+        <span style={{
+          ...spanStyle,
+          ...this.props.styles.getPreviewStyle('Iterable', this.state.expanded)
+        }} onClick={::this.handleClick}>
+          {this.getItemString(<span style={styles.spanType}>()</span>)}
         </span>
-        <ol style={childListStyle}>
+        <ol style={{
+          ...childListStyle,
+          ...this.props.styles.getListStyle('Iterable', this.state.expanded)
+        }}>
           {childNodes}
         </ol>
       </li>

--- a/src/JSONNullNode.js
+++ b/src/JSONNullNode.js
@@ -28,11 +28,15 @@ export default class JSONNullNode extends React.Component {
       <li style={{ ...styles.base, backgroundColor }} onClick={::this.handleClick}>
         <label style={{
           ...styles.label,
-          color: this.props.theme.base0D
+          color: this.props.theme.base0D,
+          ...this.props.styles.getLabelStyle('Null', true)
         }}>
           {this.props.keyName}:
         </label>
-        <span style={{ color: this.props.theme.base08 }}>null</span>
+        <span style={{
+          color: this.props.theme.base08,
+          ...this.props.styles.getValueStyle('Null', true)
+        }}>null</span>
       </li>
     );
   }

--- a/src/JSONNumberNode.js
+++ b/src/JSONNumberNode.js
@@ -28,11 +28,15 @@ export default class JSONNumberNode extends React.Component {
       <li style={{ ...styles.base, backgroundColor }} onClick={::this.handleClick}>
         <label style={{
           ...styles.label,
-          color: this.props.theme.base0D
+          color: this.props.theme.base0D,
+          ...this.props.styles.getLabelStyle('Number', true)
         }}>
           {this.props.keyName}:
         </label>
-        <span style={{ color: this.props.theme.base09 }}>{this.props.value}</span>
+        <span style={{
+          color: this.props.theme.base09,
+          ...this.props.styles.getValueStyle('Number', true)
+        }}>{this.props.value}</span>
       </li>
     );
   }

--- a/src/JSONObjectNode.js
+++ b/src/JSONObjectNode.js
@@ -80,7 +80,7 @@ export default class JSONObjectNode extends React.Component {
       const len = Object.keys(this.props.data).length;
       this.itemString = len + ' key' + (len !== 1 ? 's' : '');
     }
-    return this.props.getItemString('Object', this.props.data, this.itemString, itemType);
+    return this.props.getItemString('Object', this.props.data, itemType, this.itemString);
   }
 
   render() {

--- a/src/JSONObjectNode.js
+++ b/src/JSONObjectNode.js
@@ -61,7 +61,7 @@ export default class JSONObjectNode extends React.Component {
           if (typeof this.props.previousData !== 'undefined' && this.props.previousData !== null) {
             prevData = this.props.previousData[k];
           }
-          const node = grabNode(k, obj[k], prevData, this.props.theme);
+          const node = grabNode(k, obj[k], prevData, this.props.theme, this.props.styles, this.props.getItemString);
           if (node !== false) {
             childNodes.push(node);
           }
@@ -75,12 +75,12 @@ export default class JSONObjectNode extends React.Component {
 
   // Returns the "n Items" string for this node, generating and
   // caching it if it hasn't been created yet.
-  getItemString() {
+  getItemString(itemType) {
     if (!this.itemString) {
       const len = Object.keys(this.props.data).length;
       this.itemString = len + ' key' + (len !== 1 ? 's' : '');
     }
-    return this.itemString;
+    return this.props.getItemString('Object', this.props.data, this.itemString, itemType);
   }
 
   render() {
@@ -106,18 +106,24 @@ export default class JSONObjectNode extends React.Component {
     }
     return (
       <li style={containerStyle}>
-        <JSONArrow theme={this.props.theme} open={this.state.expanded} onClick={::this.handleClick}/>
+        <JSONArrow theme={this.props.theme} open={this.state.expanded} onClick={::this.handleClick} style={this.props.styles.getArrowStyle(this.state.expanded)} />
         <label style={{
           ...styles.label,
-          color: this.props.theme.base0D
+          color: this.props.theme.base0D,
+          ...this.props.styles.getLabelStyle('Object', this.state.expanded)
         }} onClick={::this.handleClick}>
           {this.props.keyName}:
         </label>
-        <span style={spanStyle} onClick={::this.handleClick}>
-          <span style={styles.spanType}>&#123;&#125;</span>
-          {this.getItemString()}
+        <span style={{
+          ...spanStyle,
+          ...this.props.styles.getPreviewStyle('Object', this.state.expanded)
+        }} onClick={::this.handleClick}>
+          {this.getItemString(<span style={styles.spanType}>&#123;&#125;</span>)}
         </span>
-        <ul style={childListStyle}>
+        <ul style={{
+          ...childListStyle,
+          ...this.props.styles.getListStyle('Object', this.state.expanded)
+        }}>
           {this.getChildNodes()}
         </ul>
       </li>

--- a/src/JSONObjectNode.js
+++ b/src/JSONObjectNode.js
@@ -116,7 +116,7 @@ export default class JSONObjectNode extends React.Component {
         </label>
         <span style={{
           ...spanStyle,
-          ...this.props.styles.getPreviewStyle('Object', this.state.expanded)
+          ...this.props.styles.getItemStringStyle('Object', this.state.expanded)
         }} onClick={::this.handleClick}>
           {this.getItemString(<span style={styles.spanType}>&#123;&#125;</span>)}
         </span>

--- a/src/JSONStringNode.js
+++ b/src/JSONStringNode.js
@@ -28,11 +28,15 @@ export default class JSONStringNode extends React.Component {
       <li style={{ ...styles.base, backgroundColor }} onClick={::this.handleClick}>
         <label style={{
           ...styles.label,
-          color: this.props.theme.base0D
+          color: this.props.theme.base0D,
+          ...this.props.styles.getLabelStyle('String', true)
         }}>
           {this.props.keyName}:
         </label>
-        <span style={{ color: this.props.theme.base0B }}>"{this.props.value}"</span>
+        <span style={{
+          color: this.props.theme.base0B,
+          ...this.props.styles.getValueStyle('String', true)
+        }}>"{this.props.value}"</span>
       </li>
     );
   }

--- a/src/grab-node.js
+++ b/src/grab-node.js
@@ -9,24 +9,24 @@ import JSONBooleanNode from './JSONBooleanNode';
 import JSONNullNode from './JSONNullNode';
 import JSONDateNode from './JSONDateNode';
 
-export default function(key, value, prevValue, theme, initialExpanded = false) {
+export default function(key, value, prevValue, theme, styles, getItemString, initialExpanded = false) {
   const nodeType = objType(value);
   if (nodeType === 'Object') {
-    return <JSONObjectNode data={value} previousData={prevValue} theme={theme} initialExpanded={initialExpanded} keyName={key} key={key} />;
+    return <JSONObjectNode data={value} previousData={prevValue} theme={theme} initialExpanded={initialExpanded} keyName={key} key={key} styles={styles} getItemString={getItemString} />;
   } else if (nodeType === 'Array') {
-    return <JSONArrayNode data={value} previousData={prevValue} theme={theme} initialExpanded={initialExpanded} keyName={key} key={key} />;
+    return <JSONArrayNode data={value} previousData={prevValue} theme={theme} initialExpanded={initialExpanded} keyName={key} key={key} styles={styles} getItemString={getItemString} />;
   } else if (nodeType === 'Iterable') {
-    return <JSONIterableNode data={value} previousData={prevValue} theme={theme} initialExpanded={initialExpanded} keyName={key} key={key} />;
+    return <JSONIterableNode data={value} previousData={prevValue} theme={theme} initialExpanded={initialExpanded} keyName={key} key={key} styles={styles} getItemString={getItemString} />;
   } else if (nodeType === 'String') {
-    return <JSONStringNode keyName={key} previousValue={prevValue} theme={theme} value={value} key={key} />;
+    return <JSONStringNode keyName={key} previousValue={prevValue} theme={theme} value={value} key={key} styles={styles} />;
   } else if (nodeType === 'Number') {
-    return <JSONNumberNode keyName={key} previousValue={prevValue} theme={theme} value={value} key={key} />;
+    return <JSONNumberNode keyName={key} previousValue={prevValue} theme={theme} value={value} key={key} styles={styles} />;
   } else if (nodeType === 'Boolean') {
-    return <JSONBooleanNode keyName={key} previousValue={prevValue} theme={theme} value={value} key={key} />;
+    return <JSONBooleanNode keyName={key} previousValue={prevValue} theme={theme} value={value} key={key} styles={styles} />;
   } else if (nodeType === 'Date') {
-    return <JSONDateNode keyName={key} previousValue={prevValue} theme={theme} value={value} key={key} />;
+    return <JSONDateNode keyName={key} previousValue={prevValue} theme={theme} value={value} key={key} styles={styles} />;
   } else if (nodeType === 'Null') {
-    return <JSONNullNode keyName={key} previousValue={prevValue} theme={theme} value={value} key={key} />;
+    return <JSONNullNode keyName={key} previousValue={prevValue} theme={theme} value={value} key={key} styles={styles} />;
   }
   return false;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,8 @@ const styles = {
     }
 };
 
+const getEmptyStyle = () => ({});
+
 export default class JSONTree extends React.Component {
   static propTypes = {
     data: React.PropTypes.oneOfType([
@@ -31,7 +33,13 @@ export default class JSONTree extends React.Component {
   };
 
   static defaultProps = {
-    theme: solarized
+    theme: solarized,
+    getArrowStyle: getEmptyStyle,
+    getListStyle: getEmptyStyle,
+    getPreviewStyle: getEmptyStyle,
+    getLabelStyle: getEmptyStyle,
+    getValueStyle: getEmptyStyle,
+    getItemString: (type, data, itemString, itemType) => <span>{itemType} {itemString}</span>
   };
 
   constructor(props) {
@@ -40,7 +48,14 @@ export default class JSONTree extends React.Component {
 
   render() {
     const keyName = this.props.keyName || 'root';
-    const rootNode = grabNode(keyName, this.props.data, this.props.previousData, this.props.theme, true);
+    const getStyles = {
+      getArrowStyle: this.props.getArrowStyle,
+      getListStyle: this.props.getListStyle,
+      getPreviewStyle: this.props.getPreviewStyle,
+      getLabelStyle: this.props.getLabelStyle,
+      getValueStyle: this.props.getValueStyle
+    };
+    const rootNode = grabNode(keyName, this.props.data, this.props.previousData, this.props.theme, getStyles, this.props.getItemString, true);
     return (
       <ul style={{
         ...styles.tree,

--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,7 @@ export default class JSONTree extends React.Component {
     theme: solarized,
     getArrowStyle: getEmptyStyle,
     getListStyle: getEmptyStyle,
-    getPreviewStyle: getEmptyStyle,
+    getItemStringStyle: getEmptyStyle,
     getLabelStyle: getEmptyStyle,
     getValueStyle: getEmptyStyle,
     getItemString: (type, data, itemString, itemType) => <span>{itemType} {itemString}</span>
@@ -51,7 +51,7 @@ export default class JSONTree extends React.Component {
     const getStyles = {
       getArrowStyle: this.props.getArrowStyle,
       getListStyle: this.props.getListStyle,
-      getPreviewStyle: this.props.getPreviewStyle,
+      getItemStringStyle: this.props.getItemStringStyle,
       getLabelStyle: this.props.getLabelStyle,
       getValueStyle: this.props.getValueStyle
     };

--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ export default class JSONTree extends React.Component {
     getItemStringStyle: getEmptyStyle,
     getLabelStyle: getEmptyStyle,
     getValueStyle: getEmptyStyle,
-    getItemString: (type, data, itemString, itemType) => <span>{itemType} {itemString}</span>
+    getItemString: (type, data, itemType, itemString) => <span>{itemType} {itemString}</span>
   };
 
   constructor(props) {


### PR DESCRIPTION
This PR adds these props for customizing tree (all are optional):
```jsx
<JSONTree getArrowStyle={(type, expanded) => ({})}
    getItemStringStyle={(type, expanded) => ({})}
    getListStyle={(type, expanded) => ({})}
    getLabelStyle={(type, expanded) => ({})}
    getValueStyle={(type, expanded) => ({})} />
```
Here `type` is a string representing type of data, `expanded` is a current state for expandable items. Each function returns a style object, which extends corresponding default style.

There is also optional `getItemString` prop, which allows to replace item description. By default: 
```jsx
(type, data, itemType, itemString) => <span>{itemType} {itemString}</span>
```

