### PR TITLE
Allow React 0.13.1 and 0.13.2 as peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "rimraf": "^2.3.4"
   },
   "peerDependencies": {
-    "react": ">=0.13.3 || ^0.14.0-beta3"
+    "react": ">=0.13.1 || ^0.14.0-beta3"
   },
   "dependencies": {
     "babel-runtime": "^5.8.20",


### PR DESCRIPTION
This library should work fine with React 0.13.1 and 0.13.2. Our team is still using 0.13.1 and accepting this change would help us out.