### PR TITLE
Add prop for expanding all nodes

### DIFF
--- a/src/JSONArrayNode.js
+++ b/src/JSONArrayNode.js
@@ -24,7 +24,8 @@ function getChildNodes({
   previousData,
   styles,
   theme,
-  valueRenderer
+  valueRenderer,
+  allExpanded
 }) {
   const childNodes = [];
   data.forEach((value, key) => {
@@ -42,7 +43,8 @@ function getChildNodes({
       styles,
       theme,
       value,
-      valueRenderer
+      valueRenderer,
+      allExpanded
     });
 
     if (node !== false) {

--- a/src/JSONIterableNode.js
+++ b/src/JSONIterableNode.js
@@ -32,7 +32,8 @@ function getChildNodes({
   previousData,
   styles,
   theme,
-  valueRenderer
+  valueRenderer,
+  allExpanded
 }) {
   const childNodes = [];
   for (const entry of data) {
@@ -58,7 +59,8 @@ function getChildNodes({
       styles,
       theme,
       value,
-      valueRenderer
+      valueRenderer,
+      allExpanded
     });
 
     if (node !== false) {

--- a/src/JSONNestedNode.js
+++ b/src/JSONNestedNode.js
@@ -32,7 +32,8 @@ const styles = {
 export default class JSONNestedNode extends React.Component {
   defaultProps = {
     data: [],
-    initialExpanded: false
+    initialExpanded: false,
+    allExpanded: false
   };
 
   // cache store for the number of items string we display
@@ -47,7 +48,7 @@ export default class JSONNestedNode extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      expanded: this.props.initialExpanded,
+      expanded: this.props.initialExpanded || this.props.allExpanded,
       createdChildNodes: false
     };
   }

--- a/src/JSONObjectNode.js
+++ b/src/JSONObjectNode.js
@@ -25,7 +25,8 @@ function getChildNodes({
   previousData,
   styles,
   theme,
-  valueRenderer
+  valueRenderer,
+  allExpanded
 }) {
   const childNodes = [];
   for (let key in data) {
@@ -44,7 +45,8 @@ function getChildNodes({
         styles,
         theme,
         value: data[key],
-        valueRenderer
+        valueRenderer,
+        allExpanded
       });
 
       if (node !== false) {

--- a/src/grab-node.js
+++ b/src/grab-node.js
@@ -8,6 +8,7 @@ import JSONValueNode from './JSONValueNode';
 export default function({
   getItemString,
   initialExpanded = false,
+  allExpanded,
   key,
   labelRenderer,
   previousData,
@@ -36,6 +37,7 @@ export default function({
     ...simpleNodeProps,
     data: value,
     initialExpanded,
+    allExpanded,
     keyName: key
   };
 

--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,7 @@ export default class JSONTree extends React.Component {
 
   static defaultProps = {
     expandRoot: true,
+    expandAll: false,
     keyName: 'root',
     theme: solarized,
     getArrowStyle: getEmptyStyle,
@@ -63,6 +64,7 @@ export default class JSONTree extends React.Component {
     const {
       data: value,
       expandRoot: initialExpanded,
+      expandAll: allExpanded,
       getItemString,
       labelRenderer,
       valueRenderer,
@@ -74,6 +76,7 @@ export default class JSONTree extends React.Component {
     const rootNode = grabNode({
       getItemString,
       initialExpanded,
+      allExpanded,
       key,
       previousData,
       styles: getStyles,


### PR DESCRIPTION
Having an option for rendering the JSON with all nodes expanded by default would be useful. Adding an `expandAll` prop to provide this functionality.