### PR TITLE
Fixed regression in displayed values that caused all values to be displayed as strings

### DIFF
--- a/src/JSONValueNode.js
+++ b/src/JSONValueNode.js
@@ -46,8 +46,8 @@ export default class JSONValueNode extends React.Component {
         </label>
         <span style={{
           color: this.props.theme.base0B,
-          ...this.props.styles.getValueStyle('String', true)
-        }}>"{this.props.valueRenderer(this.props.valueGetter(this.props.value))}"</span>
+          ...this.props.styles.getValueStyle(this.props.nodeType, true)
+        }}>{this.props.valueRenderer(this.props.valueGetter(this.props.value))}</span>
       </li>
     );
   }

--- a/src/JSONValueNode.js
+++ b/src/JSONValueNode.js
@@ -45,7 +45,7 @@ export default class JSONValueNode extends React.Component {
           {this.props.labelRenderer(this.props.keyName)}:
         </label>
         <span style={{
-          color: this.props.theme.base0B,
+          color: this.props.valueColor,
           ...this.props.styles.getValueStyle(this.props.nodeType, true)
         }}>{this.props.valueRenderer(this.props.valueGetter(this.props.value))}</span>
       </li>

--- a/src/grab-node.js
+++ b/src/grab-node.js
@@ -47,7 +47,7 @@ export default function({
     case 'Iterable':
       return <JSONIterableNode {...nestedNodeProps} />;
     case 'String':
-      return <JSONValueNode {...simpleNodeProps} />;
+      return <JSONValueNode {...simpleNodeProps} valueGetter={raw => `"${raw}"`} />;
     case 'Number':
       return <JSONValueNode {...simpleNodeProps} />;
     case 'Boolean':
@@ -55,9 +55,9 @@ export default function({
     case 'Date':
       return <JSONValueNode {...simpleNodeProps} valueGetter={raw => raw.toISOString()} />;
     case 'Null':
-      return <JSONValueNode {...simpleNodeProps} valueGetter={() => null} />;
+      return <JSONValueNode {...simpleNodeProps} valueGetter={() => 'null'} />;
     case 'Undefined':
-      return <JSONValueNode {...simpleNodeProps} valueGetter={() => undefined} />;
+      return <JSONValueNode {...simpleNodeProps} valueGetter={() => 'undefined'} />;
     case 'Function':
       return <JSONValueNode {...simpleNodeProps} valueGetter={raw => raw.toString()} />;
     default:

--- a/src/grab-node.js
+++ b/src/grab-node.js
@@ -47,19 +47,19 @@ export default function({
     case 'Iterable':
       return <JSONIterableNode {...nestedNodeProps} />;
     case 'String':
-      return <JSONValueNode {...simpleNodeProps} valueGetter={raw => `"${raw}"`} />;
+      return <JSONValueNode {...simpleNodeProps} valueColor={theme.base0B} valueGetter={raw => `"${raw}"`} />;
     case 'Number':
-      return <JSONValueNode {...simpleNodeProps} />;
+      return <JSONValueNode {...simpleNodeProps} valueColor={theme.base09} />;
     case 'Boolean':
-      return <JSONValueNode {...simpleNodeProps} valueGetter={raw => raw ? 'true' : 'false'} />;
+      return <JSONValueNode {...simpleNodeProps} valueColor={theme.base09} valueGetter={raw => raw ? 'true' : 'false'} />;
     case 'Date':
-      return <JSONValueNode {...simpleNodeProps} valueGetter={raw => raw.toISOString()} />;
+      return <JSONValueNode {...simpleNodeProps} valueColor={theme.base0B} valueGetter={raw => raw.toISOString()} />;
     case 'Null':
-      return <JSONValueNode {...simpleNodeProps} valueGetter={() => 'null'} />;
+      return <JSONValueNode {...simpleNodeProps} valueColor={theme.base08} valueGetter={() => 'null'} />;
     case 'Undefined':
-      return <JSONValueNode {...simpleNodeProps} valueGetter={() => 'undefined'} />;
+      return <JSONValueNode {...simpleNodeProps} valueColor={theme.base08} valueGetter={() => 'undefined'} />;
     case 'Function':
-      return <JSONValueNode {...simpleNodeProps} valueGetter={raw => raw.toString()} />;
+      return <JSONValueNode {...simpleNodeProps} valueColor={theme.base08} valueGetter={raw => raw.toString()} />;
     default:
       return false;
   }


### PR DESCRIPTION
Resolves #19

Before this fix:
<img width="315" alt="screen shot 2016-01-12 at 8 37 41 am" src="https://cloud.githubusercontent.com/assets/29597/12269749/ca6af712-b907-11e5-87f0-e9218a6b1ba1.png">

After this fix:
<img width="302" alt="screen shot 2016-01-12 at 8 36 52 am" src="https://cloud.githubusercontent.com/assets/29597/12269751/ce7392ce-b907-11e5-980c-75e6ef11e04d.png">
