### PR TITLE
Create a container for JSONArrow for easier clickability/UX

### DIFF
--- a/src/JSONArrow.js
+++ b/src/JSONArrow.js
@@ -5,7 +5,6 @@ const styles = {
     display: 'inline-block',
     marginLeft: 0,
     marginTop: 8,
-    marginRight: 5,
     'float': 'left',
     transition: '150ms',
     WebkitTransition: '150ms',
@@ -15,8 +14,13 @@ const styles = {
     transform: 'rotateZ(-90deg)',
     position: 'relative'
   },
-  baseDouble: {
-    marginRight: 10
+  container: {
+    display: 'inline-block',
+    padding: '2 5',
+    cursor: 'pointer'
+  },
+  containerDouble: {
+    padding: '2 10'
   },
   arrow: {
     borderLeft: '5px solid transparent',
@@ -38,6 +42,9 @@ const styles = {
 
 export default class JSONArrow extends React.Component {
   render() {
+    let containerStyle = {
+      ...styles.container
+    };
     let style = {
       ...styles.base,
       ...styles.arrow
@@ -52,9 +59,9 @@ export default class JSONArrow extends React.Component {
       };
     }
     if (this.props.double) {
-      style = {
-        ...style,
-        ...styles.baseDouble
+      containerStyle = {
+        ...containerStyle,
+        ...styles.containerDouble
       };
     }
     style = {
@@ -62,10 +69,12 @@ export default class JSONArrow extends React.Component {
       ...this.props.style
     };
     return (
-      <div style={{ ...color, ...style }} onClick={this.props.onClick}>
-        {this.props.double &&
-          <div style={{ ...color, ...styles.inner, ...styles.arrow }} />
-        }
+      <div style={containerStyle} onClick={this.props.onClick}>
+        <div style={{ ...color, ...style }}>
+          {this.props.double &&
+            <div style={{ ...color, ...styles.inner, ...styles.arrow }} />
+          }
+        </div>
       </div>
     );
   }

--- a/src/JSONNestedNode.js
+++ b/src/JSONNestedNode.js
@@ -73,7 +73,8 @@ const STYLES = {
   label: {
     margin: 0,
     padding: 0,
-    display: 'inline-block'
+    display: 'inline-block',
+    cursor: 'pointer'
   },
   span: {
     cursor: 'default'


### PR DESCRIPTION
I've been using redux dev tools (via the extension) for a couple weeks now and it's always been overly difficult to click on the JSONArrow to expand/collapse the node. It is only after inspecting the extensions that I realized that you can click on the label as well.

Previously it was difficult to tell that you could click on the label because there is no visual indicator that you can click on it. Ideally there would be an actual visual change as well but inline styles don't support `:hover` so it doesn't appear to be possible to me without changing how this project is structured or consumed ([or with mouseover/mouseout](http://stackoverflow.com/questions/1033156/how-to-write-ahover-in-inline-css) which was too invasive for this first change).

So the solution I developed was to add a container with padding to JSONArrow and add `cursor: pointer`. I believe that this will help the usability of react-json-tree and redux dev tools.