### PR TITLE
recursive entry grouping for huge collections

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "dependencies": {
     "babel-plugin-transform-runtime": "^6.5.0",
     "babel-runtime": "^6.3.13",
-    "react-mixin": "^1.7.0"
+    "react-mixin": "^1.7.0",
+    "react-pure-render": "^1.0.2"
   }
 }

--- a/src/ItemRange.js
+++ b/src/ItemRange.js
@@ -1,0 +1,49 @@
+import React, { Component } from 'react';
+import shouldPureComponentUpdate from 'react-pure-render/function';
+import JSONArrow from './JSONArrow';
+
+const STYLES = {
+  itemRange: {
+    margin: '8px 0 8px 14px',
+    cursor: 'pointer'
+  }
+};
+
+
+export default class ItemRange extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { expanded: false };
+
+    this.handleClick = this.handleClick.bind(this);
+  }
+
+  static propTypes = {
+  }
+
+  shouldComponentUpdate = shouldPureComponentUpdate;
+
+  render() {
+    const { theme, styles, from, to, getChildNodes } = this.props;
+
+    return (this.state.expanded ?
+      <div style={{ color: theme.base0D, ...styles.label }}>
+        {getChildNodes(this.props, from, to)}
+      </div> :
+      <div style={{ color: theme.base0D, ...STYLES.itemRange, ...styles.label }}
+           onClick={this.handleClick}>
+        <JSONArrow
+          theme={theme}
+          open={false}
+          onClick={this.handleClick}
+          style={styles.getArrowStyle(false)}
+          double />
+        {`${from} ... ${to}`}
+      </div>
+    );
+  }
+
+  handleClick() {
+    this.setState({ expanded: !this.state.expanded });
+  }
+}

--- a/src/JSONArrayNode.js
+++ b/src/JSONArrayNode.js
@@ -1,59 +1,9 @@
 import React from 'react';
 import JSONNestedNode from './JSONNestedNode';
-import grabNode from './grab-node';
 
 // Returns the "n Items" string for this node, generating and caching it if it hasn't been created yet.
-function renderItemString({
-  data,
-  getItemString,
-  itemString,
-  itemType
-}) {
-  if (!itemString) {
-    itemString = data.length + ' item' + (data.length !== 1 ? 's' : '');
-  }
-  return getItemString('Array', data, itemType, itemString);
-}
-
-// Returns the child nodes for each entry in iterable.
-// If we have generated them previously we return from cache; otherwise we create them.
-function getChildNodes({
-  data,
-  getItemString,
-  labelRenderer,
-  previousData,
-  styles,
-  theme,
-  valueRenderer,
-  allExpanded,
-  keyPath
-}) {
-  const childNodes = [];
-  data.forEach((value, key) => {
-    let previousDataValue;
-    if (typeof previousData !== 'undefined' && previousData !== null) {
-      previousDataValue = previousData[key];
-    }
-
-    const node = grabNode({
-      getItemString,
-      keyPath: [key, ...keyPath],
-      labelRenderer,
-      previousData: previousDataValue,
-      renderItemString,
-      styles,
-      theme,
-      value,
-      valueRenderer,
-      allExpanded
-    });
-
-    if (node !== false) {
-      childNodes.push(node);
-    }
-  });
-
-  return childNodes;
+function createItemString(data) {
+  return `${data.length} ${data.length !== 1 ? 'items' : 'item'}`;
 }
 
 // Configures <JSONNestedNode> to render an Array
@@ -61,10 +11,9 @@ export default function JSONArrayNode({ ...props }) {
   return (
     <JSONNestedNode
       {...props}
-      getChildNodes={getChildNodes}
       nodeType='Array'
       nodeTypeIndicator='[]'
-      renderItemString={renderItemString}
+      createItemString={createItemString}
     />
   );
 }

--- a/src/JSONArrow.js
+++ b/src/JSONArrow.js
@@ -10,18 +10,29 @@ const styles = {
     transition: '150ms',
     WebkitTransition: '150ms',
     MozTransition: '150ms',
+    WebkitTransform: 'rotateZ(-90deg)',
+    MozTransform: 'rotateZ(-90deg)',
+    transform: 'rotateZ(-90deg)',
+    position: 'relative'
+  },
+  baseDouble: {
+    marginRight: 10
+  },
+  arrow: {
     borderLeft: '5px solid transparent',
     borderRight: '5px solid transparent',
     borderTopWidth: 5,
-    borderTopStyle: 'solid',
-    WebkitTransform: 'rotateZ(-90deg)',
-    MozTransform: 'rotateZ(-90deg)',
-    transform: 'rotateZ(-90deg)'
+    borderTopStyle: 'solid'
   },
   open: {
     WebkitTransform: 'rotateZ(0deg)',
     MozTransform: 'rotateZ(0deg)',
     transform: 'rotateZ(0deg)'
+  },
+  inner: {
+    position: 'absolute',
+    top: 0,
+    left: -5
   }
 };
 
@@ -29,6 +40,9 @@ export default class JSONArrow extends React.Component {
   render() {
     let style = {
       ...styles.base,
+      ...styles.arrow
+    };
+    const color = {
       borderTopColor: this.props.theme.base0D
     };
     if (this.props.open) {
@@ -37,10 +51,22 @@ export default class JSONArrow extends React.Component {
         ...styles.open
       };
     }
+    if (this.props.double) {
+      style = {
+        ...style,
+        ...styles.baseDouble
+      };
+    }
     style = {
       ...style,
       ...this.props.style
     };
-    return <div style={style} onClick={this.props.onClick}/>;
+    return (
+      <div style={{ ...color, ...style }} onClick={this.props.onClick}>
+        {this.props.double &&
+          <div style={{ ...color, ...styles.inner, ...styles.arrow }} />
+        }
+      </div>
+    );
   }
 }

--- a/src/JSONIterableNode.js
+++ b/src/JSONIterableNode.js
@@ -1,75 +1,22 @@
 import React from 'react';
 import JSONNestedNode from './JSONNestedNode';
-import grabNode from './grab-node';
 
 // Returns the "n Items" string for this node, generating and caching it if it hasn't been created yet.
-function renderItemString({
-  data,
-  getItemString,
-  itemString,
-  itemType
-}) {
-  if (!itemString) {
-    let count = 0;
-    if (Number.isSafeInteger(data.size)) {
-      count = data.size;
-    } else {
-      for (const entry of data) { // eslint-disable-line no-unused-vars
-        count += 1;
+function createItemString(data, limit) {
+  let count = 0;
+  let hasMore = false;
+  if (Number.isSafeInteger(data.size)) {
+    count = data.size;
+  } else {
+    for (const entry of data) { // eslint-disable-line no-unused-vars
+      if (limit && count + 1 > limit) {
+        hasMore = true;
+        break;
       }
-    }
-    itemString = count + ' entr' + (count !== 1 ? 'ies' : 'y');
-  }
-  return getItemString('Iterable', data, itemType, itemString);
-}
-
-// Returns the child nodes for each entry in iterable.
-// If we have generated them previously we return from cache; otherwise we create them.
-function getChildNodes({
-  data,
-  getItemString,
-  labelRenderer,
-  previousData,
-  styles,
-  theme,
-  valueRenderer,
-  allExpanded,
-  keyPath
-}) {
-  const childNodes = [];
-  for (const entry of data) {
-    let key = null;
-    let value = null;
-    if (Array.isArray(entry)) {
-      [key, value] = entry;
-    } else {
-      key = childNodes.length;
-      value = entry;
-    }
-
-    let previousDataValue;
-    if (typeof previousData !== 'undefined' && previousData !== null) {
-      previousDataValue = previousData[key];
-    }
-
-    const node = grabNode({
-      getItemString,
-      keyPath: [key, ...keyPath],
-      labelRenderer,
-      previousData: previousDataValue,
-      styles,
-      theme,
-      value,
-      valueRenderer,
-      allExpanded
-    });
-
-    if (node !== false) {
-      childNodes.push(node);
+      count += 1;
     }
   }
-
-  return childNodes;
+  return `${hasMore ? '>' : ''}${count} ${count !== 1 ? 'entries' : 'entry'}`;
 }
 
 // Configures <JSONNestedNode> to render an iterable
@@ -77,10 +24,9 @@ export default function({ ...props }) {
   return (
     <JSONNestedNode
       {...props}
-      getChildNodes={getChildNodes}
       nodeType='Iterable'
       nodeTypeIndicator='()'
-      renderItemString={renderItemString}
+      createItemString={createItemString}
     />
   );
 }

--- a/src/JSONNestedNode.js
+++ b/src/JSONNestedNode.js
@@ -2,12 +2,68 @@ import React from 'react';
 import reactMixin from 'react-mixin';
 import { ExpandedStateHandlerMixin } from './mixins';
 import JSONArrow from './JSONArrow';
+import getCollectionEntries from './getCollectionEntries';
+import grabNode from './grab-node';
+import ItemRange from './ItemRange';
+import shouldPureComponentUpdate from 'react-pure-render/function';
 
 /**
  * Renders nested values (eg. objects, arrays, lists, etc.)
  */
 
-const styles = {
+function getChildNodes(props, from, to) {
+  const {
+    nodeType,
+    data,
+    collectionLimit,
+    previousData,
+    circularCache,
+    keyPath,
+    postprocessValue,
+    allExpanded
+  } = props;
+  const childNodes = [];
+
+  getCollectionEntries(nodeType, data, collectionLimit, from, to).forEach(entry => {
+    if (entry.to) {
+      childNodes.push(
+        <ItemRange {...props}
+                   key={`ItemRange${entry.from}-${entry.to}`}
+                   from={entry.from}
+                   to={entry.to}
+                   getChildNodes={getChildNodes} />
+      );
+    } else {
+      const { key, value } = entry;
+      let previousDataValue;
+      if (typeof previousData !== 'undefined' && previousData !== null) {
+        previousDataValue = previousData[key];
+      }
+      const isCircular = circularCache.indexOf(value) !== -1;
+
+      const node = grabNode({
+        ...props,
+        keyPath: [key, ...keyPath],
+        previousData: previousDataValue,
+        value: postprocessValue(value),
+        postprocessValue,
+        collectionLimit,
+        circularCache: [...circularCache, value],
+        initialExpanded: false,
+        allExpanded: isCircular ? false : allExpanded,
+        hideRoot: false
+      });
+
+      if (node !== false) {
+        childNodes.push(node);
+      }
+    }
+  });
+
+  return childNodes;
+}
+
+const STYLES = {
   base: {
     position: 'relative',
     paddingTop: 3,
@@ -30,20 +86,12 @@ const styles = {
 
 @reactMixin.decorate(ExpandedStateHandlerMixin)
 export default class JSONNestedNode extends React.Component {
-  defaultProps = {
+  static defaultProps = {
     data: [],
     initialExpanded: false,
-    allExpanded: false
+    allExpanded: false,
+    circularCache: []
   };
-
-  // cache store for the number of items string we display
-  itemString = false;
-
-  // flag to see if we still need to render our child nodes
-  needsChildNodes = true;
-
-  // cache store for our child nodes
-  renderedChildren = [];
 
   constructor(props) {
     super(props);
@@ -53,64 +101,87 @@ export default class JSONNestedNode extends React.Component {
     };
   }
 
+  shouldComponentUpdate = shouldPureComponentUpdate;
+
   render() {
-    let childListStyle = {
+    const {
+      getItemString,
+      nodeTypeIndicator,
+      nodeType,
+      data,
+      hideRoot,
+      styles,
+      createItemString,
+      theme,
+      collectionLimit,
+      keyPath,
+      labelRenderer
+    } = this.props;
+    const expanded = this.state.expanded;
+    const childListStyle = {
       padding: 0,
       margin: 0,
       listStyle: 'none',
-      display: (this.state.expanded) ? 'block' : 'none'
+      display: expanded ? 'block' : 'none'
     };
-    let containerStyle;
     let spanStyle = {
-      ...styles.span,
-      color: this.props.theme.base0B
+      ...STYLES.span,
+      color: theme.base0B
     };
-    containerStyle = {
-      ...styles.base
+    const containerStyle = {
+      ...STYLES.base
     };
-    if (this.state.expanded) {
+
+    if (expanded) {
       spanStyle = {
         ...spanStyle,
-        color: this.props.theme.base03
+        color: theme.base03
       };
     }
 
-    if (this.state.expanded && this.needsChildNodes) {
-      this.needsChildNodes = false;
-      this.renderedChildren = this.props.getChildNodes({
-        ...this.props
-      });
-    }
+    const renderedChildren = expanded ? getChildNodes(this.props) : null;
 
-    const itemType = <span style={styles.spanType}>{this.props.nodeTypeIndicator}</span>;
-    const renderedItemString = this.props.renderItemString({
-      data: this.props.data,
-      getItemString: this.props.getItemString,
-      itemString: this.itemString,
-      itemType
-    });
+    const itemType = <span style={STYLES.spanType}>{nodeTypeIndicator}</span>;
+    const renderedItemString = getItemString(
+      nodeType,
+      data,
+      itemType,
+      createItemString(data, collectionLimit)
+    );
 
-    return (
+    return hideRoot ? (
+      <div>
+        {renderedChildren}
+      </div>
+    ) : (
       <li style={containerStyle}>
-        <JSONArrow theme={this.props.theme} open={this.state.expanded} onClick={::this.handleClick} style={this.props.styles.getArrowStyle(this.state.expanded)} />
-        <label style={{
-          ...styles.label,
-          color: this.props.theme.base0D,
-          ...this.props.styles.getLabelStyle(this.props.nodeType, this.state.expanded)
-        }} onClick={::this.handleClick}>
-          {this.props.labelRenderer(...this.props.keyPath)}:
+        <JSONArrow
+          theme={theme}
+          open={expanded}
+          onClick={::this.handleClick}
+          style={styles.getArrowStyle(expanded)} />
+        <label
+          style={{
+            ...STYLES.label,
+            color: theme.base0D,
+            ...styles.getLabelStyle(nodeType, expanded)
+          }}
+          onClick={::this.handleClick}>
+          {labelRenderer(...keyPath)}:
         </label>
-        <span style={{
-          ...spanStyle,
-          ...this.props.styles.getItemStringStyle(this.props.nodeType, this.state.expanded)
-        }} onClick={::this.handleClick}>
+        <span
+          style={{
+            ...spanStyle,
+            ...styles.getItemStringStyle(nodeType, expanded)
+          }}
+          onClick={::this.handleClick}>
           {renderedItemString}
         </span>
         <ul style={{
-          ...childListStyle,
-          ...this.props.styles.getListStyle(this.props.nodeType, this.state.expanded)
-        }}>
-          {this.renderedChildren}
+              ...childListStyle,
+              ...styles.getListStyle(nodeType, expanded)
+            }}>
+          {renderedChildren}
         </ul>
       </li>
     );

--- a/src/JSONObjectNode.js
+++ b/src/JSONObjectNode.js
@@ -1,62 +1,10 @@
 import React from 'react';
 import JSONNestedNode from './JSONNestedNode';
-import grabNode from './grab-node';
 
 // Returns the "n Items" string for this node, generating and caching it if it hasn't been created yet.
-function renderItemString({
-  data,
-  getItemString,
-  itemString,
-  itemType
-}) {
-  if (!itemString) {
-    const len = Object.keys(data).length;
-    itemString = len + ' key' + (len !== 1 ? 's' : '');
-  }
-  return getItemString('Object', data, itemType, itemString);
-}
-
-// Returns the child nodes for each entry in iterable.
-// If we have generated them previously we return from cache; otherwise we create them.
-export function getChildNodes({
-  data,
-  getItemString,
-  labelRenderer,
-  previousData,
-  styles,
-  theme,
-  valueRenderer,
-  allExpanded,
-  keyPath
-}) {
-  const childNodes = [];
-  for (let key in data) {
-    if (Object.getPrototypeOf(data) === null || data.hasOwnProperty(key)) {
-      let previousDataValue;
-      if (typeof previousData !== 'undefined' && previousData !== null) {
-        previousDataValue = previousData[key];
-      }
-
-      const node = grabNode({
-        getItemString,
-        keyPath: [key, ...keyPath],
-        labelRenderer,
-        previousData: previousDataValue,
-        renderItemString,
-        styles,
-        theme,
-        value: data[key],
-        valueRenderer,
-        allExpanded
-      });
-
-      if (node !== false) {
-        childNodes.push(node);
-      }
-    }
-  }
-
-  return childNodes;
+function createItemString(data) {
+  const len = Object.keys(data).length;
+  return `${len} ${len !== 1 ? 'keys' : 'key'}`;
 }
 
 // Configures <JSONNestedNode> to render an Object
@@ -64,10 +12,9 @@ export default function({ ...props }) {
   return (
     <JSONNestedNode
       {...props}
-      getChildNodes={getChildNodes}
       nodeType='Object'
       nodeTypeIndicator='{}'
-      renderItemString={renderItemString}
+      createItemString={createItemString}
     />
   );
 }

--- a/src/JSONValueNode.js
+++ b/src/JSONValueNode.js
@@ -47,7 +47,7 @@ export default class JSONValueNode extends React.Component {
         <span style={{
           color: this.props.valueColor,
           ...this.props.styles.getValueStyle(this.props.nodeType, true)
-        }}>{this.props.valueRenderer(this.props.valueGetter(this.props.value))}</span>
+        }}>{this.props.valueRenderer(this.props.valueGetter(this.props.value), this.props.value)}</span>
       </li>
     );
   }

--- a/src/getCollectionEntries.js
+++ b/src/getCollectionEntries.js
@@ -1,0 +1,95 @@
+function getLength(type, collection) {
+  if (type === 'Object') {
+    return Object.keys(collection).length;
+  } else if (type === 'Array') {
+    return collection.length;
+  }
+
+  return Infinity;
+}
+
+function getEntries(type, collection, from=0, to=Infinity) {
+  let res;
+
+  if (type === 'Object') {
+    const keys = Object.keys(collection).slice(from, to + 1);
+
+    res = {
+      entries: keys.map(key => ({ key, value: collection[key] }))
+    };
+  } else if (type === 'Array') {
+    res = {
+      entries: collection.slice(from, to + 1).map((val, idx) => ({ key: idx + from, value: val }))
+    };
+  } else {
+    let idx = 0;
+    let entries = [];
+    let done = true;
+    for (let item of collection) {
+      if (idx > to) {
+        done = false;
+        break;
+      } if (from < idx) {
+        entries.push({ key: idx, value: item });
+      }
+      idx++;
+    }
+
+    res = {
+      hasMore: !done,
+      entries
+    };
+  }
+
+  return res;
+}
+
+function getRanges(from, to, limit) {
+  const ranges = [];
+  while (to - from > limit * limit) {
+    limit = limit * limit;
+  }
+  for (let i = from; i <= to; i += limit) {
+    ranges.push({ from: i, to: Math.min(to, i + limit - 1) });
+  }
+
+  return ranges;
+}
+
+export default function getCollectionEntries(type, collection, limit, from=0, to=Infinity) {
+  if (!limit) {
+    return getEntries(type, collection).entries;
+  }
+  const isSubset = to < Infinity;
+  const length = Math.min(to - from, getLength(type, collection));
+
+  if (type !== 'Iterable') {
+    if (length <= limit || limit < 7) {
+      return getEntries(type, collection, from, to).entries;
+    }
+  } else {
+    if (length <= limit && !isSubset) {
+      return getEntries(type, collection, from, to).entries;
+    }
+  }
+
+  let limitedEntries;
+  if (type === 'Iterable') {
+    const { hasMore, entries } = getEntries(type, collection, from, from + limit - 1);
+
+    limitedEntries = hasMore ? [
+      ...entries,
+      ...getRanges(from + limit, from + 2 * limit - 1, limit)
+    ] : entries;
+  } else {
+    limitedEntries = isSubset ?
+      getRanges(from, to, limit) :
+      [
+        ...getEntries(type, collection, 0, limit - 5).entries,
+        ...getRanges(limit - 4, length - 5, limit),
+        ...getEntries(type, collection, length - 4, length - 1).entries
+      ];
+  }
+
+  return limitedEntries;
+}

--- a/src/getCollectionEntries.js
+++ b/src/getCollectionEntries.js
@@ -29,7 +29,7 @@ function getEntries(type, collection, from=0, to=Infinity) {
       if (idx > to) {
         done = false;
         break;
-      } if (from < idx) {
+      } if (from <= idx) {
         entries.push({ key: idx, value: item });
       }
       idx++;

--- a/src/grab-node.js
+++ b/src/grab-node.js
@@ -8,16 +8,17 @@ import JSONValueNode from './JSONValueNode';
 export default function({
   getItemString,
   initialExpanded = false,
-  allExpanded,
   keyPath,
   labelRenderer,
   previousData,
   styles,
   theme,
   value,
-  valueRenderer
+  valueRenderer,
+  isCustomNode,
+  ...rest
 }) {
-  const nodeType = objType(value);
+  const nodeType = isCustomNode(value) ? 'Custom' : objType(value);
 
   const simpleNodeProps = {
     getItemString,
@@ -34,11 +35,10 @@ export default function({
   };
 
   const nestedNodeProps = {
+    ...rest,
     ...simpleNodeProps,
     data: value,
-    initialExpanded,
-    allExpanded,
-    keyPath
+    isCustomNode
   };
 
   switch (nodeType) {
@@ -62,6 +62,8 @@ export default function({
       return <JSONValueNode {...simpleNodeProps} valueColor={theme.base08} valueGetter={() => 'undefined'} />;
     case 'Function':
       return <JSONValueNode {...simpleNodeProps} valueColor={theme.base08} valueGetter={raw => raw.toString()} />;
+    case 'Custom':
+      return <JSONValueNode {...simpleNodeProps} />;
     default:
       return false;
   }

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,6 @@
 import React from 'react';
 import grabNode from './grab-node';
 import solarized from './themes/solarized';
-import {getChildNodes} from './JSONObjectNode';
 
 const styles = {
   tree: {
@@ -48,7 +47,10 @@ export default class JSONTree extends React.Component {
     getValueStyle: getEmptyStyle,
     getItemString: (type, data, itemType, itemString) => <span>{itemType} {itemString}</span>,
     labelRenderer: identity,
-    valueRenderer: identity
+    valueRenderer: identity,
+    postprocessValue: identity,
+    isCustomNode: () => false,
+    collectionLimit: 50
   };
 
   constructor(props) {
@@ -68,47 +70,30 @@ export default class JSONTree extends React.Component {
       data: value,
       expandRoot: initialExpanded,
       expandAll: allExpanded,
-      getItemString,
-      labelRenderer,
-      valueRenderer,
+      style,
       keyPath,
-      previousData,
-      theme
+      postprocessValue,
+      hideRoot,
+      ...rest
     } = this.props;
 
     let nodeToRender;
 
-    if (!this.props.hideRoot) {
-      nodeToRender = grabNode({
-        getItemString,
-        initialExpanded,
-        allExpanded,
-        keyPath,
-        previousData,
-        styles: getStyles,
-        theme,
-        labelRenderer,
-        value,
-        valueRenderer
-      });
-    } else {
-      nodeToRender = getChildNodes({
-        data: value,
-        getItemString,
-        labelRenderer,
-        previousData,
-        styles: getStyles,
-        theme,
-        valueRenderer,
-        allExpanded,
-        keyPath: []
-      });
-    }
+    nodeToRender = grabNode({
+      initialExpanded,
+      allExpanded,
+      keyPath: hideRoot ? [] : keyPath,
+      styles: getStyles,
+      value: postprocessValue(value),
+      postprocessValue,
+      hideRoot,
+      ...rest
+    });
 
     return (
       <ul style={{
         ...styles.tree,
-        ...this.props.style
+        ...style
       }}>
         {nodeToRender}
       </ul>


### PR DESCRIPTION
(there's a lot of changes, I'm sorry for that, it probably shouldn't be in one PR)

* If `Object`, `Array` or `Iterable` has more than `collectionLimit` entries (`50` by default), only `collectionLimit` entries are shown, the rest are grouped recursively (so than not more than `collectionLimit` groups are shown). If `collectionLimit = 0`, all items are shown. 

Example screencast (as a part of [redux-devtools-inspector](https://github.com/alexkuz/redux-devtools-inspector)):

![json](https://cloud.githubusercontent.com/assets/790659/13375393/0fcc65c2-ddaf-11e5-9ed4-77d4791708d8.gif)

* Added prop `postprocessValue(value)` (`identity` by default): allows to replace value on rendering. Useful for huge collections, as there is no need to traverse all entries, just the ones that are rendered.

* Added prop `isCustomNode(value)` (returns `false` by default): if returns `true`, item is rendered via `JSONValueNode`, which allows to render custom component for any type of item (not just literals). Should be used with `valueRenderer`.

* Objects with circular references are never expanded by default, even with `expandAll = true`.

* Some refactoring :)
